### PR TITLE
Make InactiveUuidsRemover thread-safe.

### DIFF
--- a/src/authentication/Authenticate.java
+++ b/src/authentication/Authenticate.java
@@ -4,6 +4,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import server.ServerSettings;
 
@@ -15,8 +16,8 @@ import server.ServerSettings;
  */
 public class Authenticate {
 
-	private static HashMap<String, String> activeUsersID = new HashMap<String, String>();
-	private static HashMap<String, Date> latestRequests = new HashMap<String, Date>();
+	private static ConcurrentHashMap<String, String> activeUsersID = new ConcurrentHashMap<String, String>();
+	private static ConcurrentHashMap<String, Date> latestRequests = new ConcurrentHashMap<String, Date>();
 
 
 	static public LoginAttempt login(String username, String password) {
@@ -53,7 +54,7 @@ public class Authenticate {
 		return new LoginAttempt(false, null, "Wrong password.");
 	}
 
-	public static HashMap<String, Date> getLatestRequestsMap() {
+	public static ConcurrentHashMap<String, Date> getLatestRequestsMap() {
 		return latestRequests;
 	}
 

--- a/src/authentication/Authenticate.java
+++ b/src/authentication/Authenticate.java
@@ -1,7 +1,6 @@
 package authentication;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/authentication/Authenticate.java
+++ b/src/authentication/Authenticate.java
@@ -15,6 +15,7 @@ import server.ServerSettings;
  */
 public class Authenticate {
 
+	// These can be modified from the InteractiveUuidsRemover thread.
 	private static ConcurrentHashMap<String, String> activeUsersID = new ConcurrentHashMap<String, String>();
 	private static ConcurrentHashMap<String, Date> latestRequests = new ConcurrentHashMap<String, Date>();
 

--- a/src/authentication/InactiveUuidsRemover.java
+++ b/src/authentication/InactiveUuidsRemover.java
@@ -3,6 +3,7 @@ package authentication;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import server.Debug;
@@ -30,7 +31,7 @@ public class InactiveUuidsRemover implements Runnable {
 		try{
 			while(true) {
 				Debug.log("LOOKING FOR INACTIVE UUIDS.");
-				HashMap<String, Date> latestRequests = Authenticate.getLatestRequestsMap();
+				ConcurrentHashMap<String, Date> latestRequests = Authenticate.getLatestRequestsMap();
 
 				// Collect all inactive User IDs...
 				ArrayList<String> usersToDelete = new ArrayList<String>();

--- a/src/authentication/InactiveUuidsRemover.java
+++ b/src/authentication/InactiveUuidsRemover.java
@@ -2,7 +2,6 @@ package authentication;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 


### PR DESCRIPTION
Modifying a HashMap concurrently from two different threads is unsafe.