### PR TITLE
UrgentHotfixOfProcessStatusCommand

### DIFF
--- a/src/response/GetProcessStatusResponse.java
+++ b/src/response/GetProcessStatusResponse.java
@@ -39,7 +39,7 @@ public class GetProcessStatusResponse extends Response {
 	@Override
 	public String getBody() {
 
-		if (processStatuses.size() > 0) {
+		if (processStatuses.isEmpty()) {
 			ErrorLogger.log("SYSTEM", "GetProcessStatusResponse.getBody(): " +
 					"Error getting process status");
 			return "";


### PR DESCRIPTION
Fixes a bug that makes the process status response always have an empty body. Should be merged with master before delivery tomorrow.