### PR TITLE
Fix so that filesize is returned instead of placeholder

### DIFF
--- a/src/response/FileInformation.java
+++ b/src/response/FileInformation.java
@@ -43,6 +43,6 @@ public class FileInformation {
     	uploader = src.uploader;
     	expId = src.expId;
     	grVersion = src.grVersion;
-        fileSize = "1000";
+        fileSize = src.fileSize;
     }
 }


### PR DESCRIPTION
 Fix so that filesize is returned instead of placeholder now that it exists in DB.