### PR TITLE
Add annotations not present in tuple on updateExperiment()

### DIFF
--- a/src/database/subClasses/ExperimentMethods.java
+++ b/src/database/subClasses/ExperimentMethods.java
@@ -11,6 +11,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -247,11 +248,13 @@ public class ExperimentMethods {
 
         // Run all SQL queries as one transaction
         int rs = 0;
+        ArrayList<String> keys = new ArrayList<>();
         try (PreparedStatement stmt = conn.prepareStatement(query);) {
             conn.setAutoCommit(false);
             for (Entry<String, String> e : annotations.entrySet()) {
                 String key = e.getKey();
                 String value = e.getValue();
+                keys.add(key);
                 stmt.setString(1, value);
                 stmt.setString(2, key);
                 stmt.setString(3, expID);
@@ -260,6 +263,11 @@ public class ExperimentMethods {
 
             int arr[] = stmt.executeBatch();
             for (int i = 0; i < arr.length; i++) {
+                if (arr[i] == 0) {
+                    String label = keys.get(i);
+                    String value = annotations.get(label);
+                    arr[i] = annotateExperiment(expID, label, value);
+                }
                 rs += arr[i];
             }
 

--- a/src/database/subClasses/ExperimentMethods.java
+++ b/src/database/subClasses/ExperimentMethods.java
@@ -273,7 +273,7 @@ public class ExperimentMethods {
 
             conn.commit();
 
-        } catch (SQLException e) {
+        } catch (SQLException | IOException e) {
             conn.rollback();
             throw e;
         } finally {

--- a/test/database/test/unittests/UpdateExperimentTest.java
+++ b/test/database/test/unittests/UpdateExperimentTest.java
@@ -148,6 +148,32 @@ public class UpdateExperimentTest {
     }
 
     @Test
+    public void shouldAddAnnotationWhenNotPresentOnMultipleUpdate() throws Exception {
+
+        String exp3 = "Exp3";
+
+        HashMap<String, String> orig = dbac.getExperiment(exp3).getAnnotations();
+        HashMap<String, String> kv = new HashMap<>();
+
+        String species = "Human";
+        String sex = "Male";
+        String devStage = "Adult";
+
+        kv.put("Species", species);
+        kv.put("Sex", sex);
+        kv.put("Development_Stage", devStage);
+
+        dbac.updateExperiment(exp3, kv);
+        Experiment e = dbac.getExperiment(exp3);
+
+        assertTrue(e.getAnnotations().get("Species").equals(species));
+        assertTrue(e.getAnnotations().get("Sex").equals(sex));
+        assertTrue(e.getAnnotations().get("Development_Stage").equals(devStage));
+
+        dbac.updateExperiment(exp3, orig);
+    }
+
+    @Test
     public void shouldNotUpdateNonExistentAnnotations() throws Exception {
 
         String exp1 = "Exp1";


### PR DESCRIPTION
If an update to an experiment annotation cannot be made it is instead added, as requested by BL.