### PR TITLE
Ignore trailing slash when looking up a command handler.

### DIFF
--- a/src/command/CommandClasses.java
+++ b/src/command/CommandClasses.java
@@ -36,71 +36,69 @@ public class CommandClasses {
     private static final HashMap<String, Class<? extends Command>> classes;
 
     static {
+        // NB: keys in the 'classes' map always end with a slash, but we support
+        // requests both with and without slash on the end
+        // (see CommandClasses.get).
+
         classes = new HashMap<>();
         // Connection Commands
-        classes.put("GET /token", IsTokenValidCommand.class);
-        classes.put("POST /login", PostLoginCommand.class);
-        classes.put("DELETE /login", DeleteLoginCommand.class);
+        classes.put("GET /token/", IsTokenValidCommand.class);
+        classes.put("POST /login/", PostLoginCommand.class);
+        classes.put("DELETE /login/", DeleteLoginCommand.class);
 
         // Experiment Commands
         classes.put("DELETE /experiment/", DeleteExperimentCommand.class);
-        classes.put("POST /experiment", PostExperimentCommand.class);
+        classes.put("POST /experiment/", PostExperimentCommand.class);
         classes.put("GET /experiment/", GetExperimentCommand.class);
         classes.put("PUT /experiment/", PutExperimentCommand.class);
 
         //File commands
-        classes.put("POST /file", PostFileCommand.class);
+        classes.put("POST /file/", PostFileCommand.class);
         classes.put("DELETE /file/", DeleteFileCommand.class);
         classes.put("GET /file/", GetFileCommand.class);
         classes.put("PUT /file/", PutFileCommand.class);
 
         //File Conversion commands
-        classes.put("PUT /convertfile", PutConvertFileCommand.class);
+        classes.put("PUT /convertfile/", PutConvertFileCommand.class);
 
         //Search commands
         classes.put("GET /search/", SearchCommand.class);
 
         //User commands
         //classes.put("PUT /user", PutUserPasswordCommand.class);
-        classes.put("PUT /user", PutUserCommand.class);
+        classes.put("PUT /user/", PutUserCommand.class);
         classes.put("GET /user/", GetUserCommand.class);
 
         //Admin commands
-        classes.put("POST /admin/user", PostAdminUserCommand.class);
+        classes.put("POST /admin/user/", PostAdminUserCommand.class);
         classes.put("DELETE /admin/user/", DeleteAdminUserCommand.class);
-        classes.put("PUT /admin/user", PutAdminUserCommand.class);
-        classes.put("GET /admin/userlist", GetAdminUserListCommand.class);
+        classes.put("PUT /admin/user/", PutAdminUserCommand.class);
+        classes.put("GET /admin/userlist/", GetAdminUserListCommand.class);
 
         //Processing
-        classes.put("GET /process", GetProcessStatusCommand.class);
-        classes.put("GET /process/dummy", GetProcessDummyCommand.class);
-        classes.put("PUT /process/rawtoprofile", PutProcessCommand.class);
-        classes.put("PUT /process/processCommands", PutProcessCommands.class);
-        classes.put("DELETE /process", CancelProcessCommand.class);
+        classes.put("GET /process/", GetProcessStatusCommand.class);
+        classes.put("GET /process/dummy/", GetProcessDummyCommand.class);
+        classes.put("PUT /process/rawtoprofile/", PutProcessCommand.class);
+        classes.put("PUT /process/processCommands/", PutProcessCommands.class);
+        classes.put("DELETE /process/", CancelProcessCommand.class);
 
         //Annotation handling commands
-        classes.put("POST /annotation/field", PostAnnotationFieldCommand.class);
-        classes.put("POST /annotation/value", PostAnnotationValueCommand.class);
+        classes.put("POST /annotation/field/", PostAnnotationFieldCommand.class);
+        classes.put("POST /annotation/value/", PostAnnotationValueCommand.class);
         classes.put("DELETE /annotation/field/", DeleteAnnotationFieldCommand.
                 class);
         classes.put("DELETE /annotation/value/", DeleteAnnotationValueCommand.
                 class);
-        classes.put("PUT /annotation/field", PutAnnotationFieldCommand.class);
-        classes.put("PUT /annotation/value", PutAnnotationValueCommand.class);
-        classes.put("GET /annotation", GetAnnotationCommand.class);
+        classes.put("PUT /annotation/field/", PutAnnotationFieldCommand.class);
+        classes.put("PUT /annotation/value/", PutAnnotationValueCommand.class);
+        classes.put("GET /annotation/", GetAnnotationCommand.class);
 
         //Genome Release handling commands
-        classes.put("POST /genomeRelease", PostGenomeReleaseCommand.class);
+        classes.put("POST /genomeRelease/", PostGenomeReleaseCommand.class);
         classes.put("DELETE /genomeRelease/", DeleteGenomeReleaseCommand.
                 class);
-        classes.put("GET /genomeRelease", GetGenomeReleaseCommand.class);
         classes.put("GET /genomeRelease/", GetGenomeReleaseSpeciesCommand.
                 class);
-
-        //Geo commands
-
-
-
     }
 
     /**
@@ -110,6 +108,9 @@ public class CommandClasses {
      * @return the class object corresponding to the given context.
      */
     public static Class<? extends Command> get(String context) {
-        return classes.get(context);
+        if (context.endsWith("/"))
+            return classes.get(context);
+        else
+            return classes.get(context + "/");
     }
 }


### PR DESCRIPTION
Makes the code a bit more consistent.