### PR TITLE
Optional support for Java smoothing.

### DIFF
--- a/settings.cfg
+++ b/settings.cfg
@@ -18,14 +18,19 @@ nrOfProcessThreads  = 5
 
 # Paths to various programs that we use.
 
-bowtieLocation      = resources/bowtie/bowtie
-picardLocation      = resources/picard-tools/picard.jar
-bowtie2Location     = resources/bowtie2/bowtie2
-pyicosLocation      = resources/pyicoteo/pyicos
+bowtieLocation		= resources/bowtie/bowtie
+picardLocation		= resources/picard-tools/picard.jar
+bowtie2Location		= resources/bowtie2/bowtie2
+pyicosLocation		= resources/pyicoteo/pyicos
+smoothingJarLocation	= resources/smoothing.jar
 
-# Settings for which bowtie version to run
+# Which bowtie version to run.
 
 shouldUseBowtie2 = false
+
+# Should the Java implementation of smoothing be used?
+
+shouldUseJavaSmoothing = false;
 
 # Address and port of the publicly visible WWW server (if any)
 # that is tunnelling requests to the genomizer server.

--- a/settings.cfg.template
+++ b/settings.cfg.template
@@ -18,10 +18,19 @@ nrOfProcessThreads  = 5
 
 # Paths to various programs that we use. Currently only 'bowtie'.
 
-bowtieLocation       = resources/bowtie/bowtie
-bowtie2Location      = resources/bowtie2/bowtie2
-picardLocation       = resources/picard/picard.jar
-pyicosLocation       = resources/pyicoteo/pyicos
+bowtieLocation		= resources/bowtie/bowtie
+picardLocation		= resources/picard-tools/picard.jar
+bowtie2Location		= resources/bowtie2/bowtie2
+pyicosLocation		= resources/pyicoteo/pyicos
+smoothingJarLocation	= resources/smoothing.jar
+
+# Which bowtie version to run.
+
+shouldUseBowtie2 = false
+
+# Should the Java implementation of smoothing be used?
+
+shouldUseJavaSmoothing = false;
 
 # Address and port of the publicly visible WWW server (if any)
 # that is tunnelling requests to the genomizer server.

--- a/src/command/process/SmoothingProcessCommand.java
+++ b/src/command/process/SmoothingProcessCommand.java
@@ -9,10 +9,12 @@ import database.containers.FileTuple;
 import database.subClasses.FileMethods;
 import org.apache.commons.io.FileUtils;
 import process.Smooth;
+import process.SmoothJava;
 import response.HttpStatusCode;
 import response.ProcessResponse;
 import response.Response;
 import server.Debug;
+import server.ServerSettings;
 
 import java.io.File;
 import java.io.IOException;
@@ -170,14 +172,27 @@ public class SmoothingProcessCommand extends ProcessCommand {
                             "Should be either 'mean' or 'median'.");
             }
 
-            Smooth.runSmoothing(
-                    infileFile.getAbsolutePath(),
-                    getWindowSize(),
-                    meanOrMedian,
-                    getMinSmooth(),
-                    0,
-                    0,
-                    outfileFile.getAbsolutePath());
+            if (!ServerSettings.shouldUseJavaSmoothing) {
+                Smooth.runSmoothing(
+                        infileFile.getAbsolutePath(),
+                        getWindowSize(),
+                        meanOrMedian,
+                        getMinSmooth(),
+                        0,
+                        0,
+                        outfileFile.getAbsolutePath());
+            }
+            else {
+                SmoothJava.runSmoothing(
+                        infileFile.getAbsolutePath(),
+                        getWindowSize(),
+                        meanOrMedian,
+                        getMinSmooth(),
+                        0,
+                        0,
+                        outfileFile.getAbsolutePath(),
+                        /* Step size, 1 == no stepping. */ 1);
+            }
 
             // Add generated file to the database.
             FileTuple outTuple = null;

--- a/src/process/Smooth.java
+++ b/src/process/Smooth.java
@@ -11,10 +11,11 @@ import java.util.ArrayList;
 
 /**
  * Class which is responsible for running smoothing.
+ * Uses the 'smooth_v4.pl' Perl script.
  */
 public class Smooth extends Executor {
 
-    private final SmoothingParameters parameters;
+    protected final SmoothingParameters parameters;
     private static final String smoothingScriptCmd   = "expect";
     private static final String smoothingScriptExp   = "resources/smooth_v4.exp";
     private static final String smoothingScriptPerl  = "resources/smooth_v4.pl";
@@ -105,7 +106,7 @@ public class Smooth extends Executor {
     /**
      * Simple wrapper around smoothing parameters.
      */
-    private class SmoothingParameters {
+    protected class SmoothingParameters {
         private String path         = null;
         private int windowSize      = 10;
         private int meanType        = 1;

--- a/src/process/SmoothJava.java
+++ b/src/process/SmoothJava.java
@@ -1,0 +1,81 @@
+package process;
+
+import command.ValidateException;
+import server.Debug;
+import server.ServerSettings;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+
+// Like process.Smooth, but uses Java code
+// from 'smoothing.SmoothingAndStep' for smoothing.
+public class SmoothJava extends Smooth {
+
+    private String inFile;
+    private String outFile;
+    private int    stepSize;
+
+    public SmoothJava (int    windowSize,
+                       int    meanType,
+                       int    minPos,
+                       int    calcTotalMean,
+                       int    printPos,
+                       String inFile,
+                       String outFile,
+                       int stepSize) {
+        super(inFile, windowSize, meanType, minPos, calcTotalMean, printPos);
+        this.inFile = inFile;
+        this.outFile = outFile;
+        this.stepSize = stepSize;
+    }
+
+    @Override
+    public void validate() throws ValidateException {
+        /* Validate parameters */
+        this.parameters.validateParameters();
+
+        /* Validate environment */
+        if (!new File(ServerSettings.smoothingJarLocation).exists())
+            throw new ValidateException(404, "Smoothing script '" +
+                    ServerSettings.smoothingJarLocation + "' is missing!");
+    }
+
+    @Override
+    public String execute() throws IOException, InterruptedException {
+        ArrayList<String> args = new ArrayList<>();
+
+        /* Time to build our command */
+        args.add("java");
+        args.add("-jar");
+        args.add(ServerSettings.smoothingJarLocation);
+        args.add(String.valueOf(parameters.getWindowSize()));
+        args.add(String.valueOf(parameters.getMeanType()));
+        args.add(String.valueOf(parameters.getMinPos()));
+        args.add(String.valueOf(parameters.getCalcTotalMean()));
+        args.add(String.valueOf(parameters.getPrintPos()));
+        args.add(inFile);
+        args.add(outFile);
+        args.add(String.valueOf(stepSize));
+
+        return executeCommand(args.toArray(new String[args.size()]));
+    }
+
+    public static void runSmoothing(String path, int windowSize, int meanType,
+                                    int minPos, int calcTotalMean, int printPos,
+                                    String outputPath, int stepSize)
+            throws ValidateException, InterruptedException, IOException {
+
+        SmoothJava smooth = new SmoothJava(windowSize, meanType, minPos,
+                calcTotalMean, printPos, path, outputPath, stepSize);
+        Debug.log("Started smoothing on " + path);
+
+        smooth.validate();
+        Debug.log("Validated smoothing on " + path);
+
+        smooth.execute();
+        Debug.log("Executed smoothing on " + path);
+
+        Debug.log("Output filename is " + outputPath);
+    }
+}

--- a/src/server/ServerSettings.java
+++ b/src/server/ServerSettings.java
@@ -20,9 +20,11 @@ public class ServerSettings {
 	public static String bowtieLocation = "resources/bowtie/bowtie";
 	public static String bowtie2Location = "resources/bowtie2/bowtie2";
 	public static String picardLocation = "resources/picard-tools/picard.jar";
+	public static String smoothingJarLocation = "resources/smoothing.jar";
 	public static int nrOfProcessThreads = 5;
 	public static String uploadTempDir = System.getProperty("java.io.tmpdir");
 	public static boolean shouldUseBowtie2 = false;
+	public static boolean shouldUseJavaSmoothing = false;
 
 	private static String downloadURL = "/download?path=";
 	private static String uploadURL = "/upload?path=";
@@ -44,6 +46,9 @@ public class ServerSettings {
 					+ "bowtieLocation = " + bowtieLocation + "\n"
 					+ "bowtie2Location = " + bowtie2Location + "\n"
 					+ "picardLocation = " + picardLocation + "\n"
+					+ "smoothingJarLocation = " + smoothingJarLocation + "\n"
+					+ "shouldUseBowtie2 = " + shouldUseBowtie2 + "\n"
+					+ "shouldUseJavaSmoothing = " + shouldUseJavaSmoothing + "\n"
 					+ "pyicosLocation = " + pyicosLocation + "\n"
 					+ "uploadTempDir = " + uploadTempDir + "\n";
 
@@ -76,8 +81,10 @@ public class ServerSettings {
 		nullCheck(bowtie2Location, "bowtie2Location");
 		nullCheck(picardLocation, "picardLocation");
 		nullCheck(pyicosLocation, "pyicosLocation");
+		nullCheck(smoothingJarLocation, "smoothingJarLocation");
 		nullCheck(uploadTempDir, "uploadTempDir");
 		nullCheck(shouldUseBowtie2, "shouldUseBowtie2");
+		nullCheck(shouldUseJavaSmoothing, "shouldUseJavaSmoothing");
 	}
 
 	private static void nullCheck(int parameter, String name) {
@@ -162,11 +169,17 @@ public class ServerSettings {
 				case "pyicoslocation":
 					pyicosLocation = value;
 					break;
+				case "smoothingjarlocation":
+					smoothingJarLocation = value;
+					break;
 				case "uploadtempdir":
 					uploadTempDir = value;
 					break;
-				case "shouldUseBowtie2":
+				case "shouldusebowtie2":
 					shouldUseBowtie2 = Boolean.parseBoolean(value);
+					break;
+				case "shouldusejavasmoothing":
+					shouldUseJavaSmoothing = Boolean.parseBoolean(value);
 					break;
 				default:
 					String msg = "Unrecognized setting: " + key;
@@ -196,7 +209,10 @@ public class ServerSettings {
 							+ "\tbowtie2Location = " + bowtie2Location + "\n"
 							+ "\tpicardLocation = " + picardLocation + "\n"
 							+ "\tpyicosLocation = " + pyicosLocation + "\n"
+							+ "\tsmoothingJarLocation = " + smoothingJarLocation + "\n"
 							+ "\tuploadTempDir = " + uploadTempDir + "\n"
+							+ "\tshouldUseBowtie2 = " + shouldUseBowtie2 + "\n"
+							+ "\tshouldUseJavaSmoothing = " + shouldUseJavaSmoothing + "\n"
 							+ "\n";
 
 			Debug.log("Imported the following settings:\n" + dataInfo);

--- a/src/smoothing/SmoothingAndStep.java
+++ b/src/smoothing/SmoothingAndStep.java
@@ -73,8 +73,8 @@ public class SmoothingAndStep {
         }
 
         try {
-            setupBuffertReader(inPath);
-            setupBuffertWriter(outPath);
+            setupBufferReader(inPath);
+            setupBufferWriter(outPath);
 
             for(int i = 0; i<params[0]; i++){
 
@@ -355,7 +355,7 @@ public class SmoothingAndStep {
         return true;
     }
 
-    private void setupBuffertWriter(String outPath) throws IOException {
+    private void setupBufferWriter(String outPath) throws IOException {
         File outFile = new File(outPath);
         if (!outFile.exists()) {
             outFile.createNewFile();
@@ -363,7 +363,7 @@ public class SmoothingAndStep {
         bw = new BufferedWriter(new FileWriter(outFile.getAbsoluteFile()));
     }
 
-    private void setupBuffertReader(String inPath) throws FileNotFoundException{
+    private void setupBufferReader(String inPath) throws FileNotFoundException{
         br = new BufferedReader(new InputStreamReader(new DataInputStream(new FileInputStream(inPath))));
     }
 

--- a/test/process/test/SmoothJavaTest.java
+++ b/test/process/test/SmoothJavaTest.java
@@ -1,0 +1,43 @@
+package process.test;
+
+import command.ValidateException;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import process.SmoothJava;
+import util.PathUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+public class SmoothJavaTest {
+
+    @Test
+    public void testJavaSmoothing()
+            throws ValidateException, IOException, InterruptedException {
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        String outDir = PathUtils.join(tmpDir, "smoothJavaOutDir/");
+        try {
+            new File(outDir).mkdirs();
+
+            SmoothJava.runSmoothing("resources/smoothTestData/SGR-testdata-2.sgr", 1, 1, 1, 0, 0,
+                    PathUtils.join(outDir, "SGR-testdata-2-smoothed.sgr"));
+            SmoothJava.runSmoothing("resources/smoothTestData/SGR-testdata-3.sgr", 2, 1, 1, 0, 0,
+                    PathUtils.join(outDir, "SGR-testdata-3-smoothed.sgr"));
+            SmoothJava.runSmoothing("resources/smoothTestData/SGR-testdata-4.sgr", 2, 1, 1, 0, 0,
+                    PathUtils.join(outDir, "SGR-testdata-4-smoothed.sgr"));
+
+            File [] finalFiles = new File(outDir).listFiles();
+            final int numFilesInOutDir = finalFiles.length;
+
+            assertEquals(3, numFilesInOutDir);
+
+            for (File file : finalFiles) {
+                assertTrue(file.length() > 0);
+            }
+        }
+        finally {
+            FileUtils.deleteDirectory(new File(outDir));
+        }
+    }
+}


### PR DESCRIPTION
Perl script is still used by default, but Java smoothing can be enabled with `shouldUseJavaSmoothing` in `settings.cfg`.