### PR TITLE
hotfix RawToProfProcess validation

### DIFF
--- a/src/command/process/RawToProfProcessCommand.java
+++ b/src/command/process/RawToProfProcessCommand.java
@@ -54,10 +54,10 @@ public class RawToProfProcessCommand extends ProcessCommand {
                     file.getGenomeVersion(),
                     MaxLength.GENOME_VERSION,
                     "Genome version");
-            Command.validateExists(
-                    file.getParams(),
-                    MaxLength.FILE_METADATA,
-                    "Parameters");
+            if(file.getParams() == null){
+                throw new ValidateException(
+                        HttpStatusCode.BAD_REQUEST, "Parameters can not be null");
+            }
             if (file.shouldKeepSam() == null) {
                 throw new ValidateException(
                         HttpStatusCode.BAD_REQUEST,


### PR DESCRIPTION
changed so that params may be empty string (still doesn't allow to be null though)
#440